### PR TITLE
Fixed Extra space in tags without attributes

### DIFF
--- a/src/models/_common/BaseObject.ts
+++ b/src/models/_common/BaseObject.ts
@@ -12,9 +12,9 @@ export class BaseObject {
       return '';
     }
 
-    const attributesStr = attributes ? `${attributes.toString()}` : '';
+    const attributesStr = attributes ? ` ${attributes.toString()}` : '';
 
-    return `<${type} ${attributesStr}>
+    return `<${type}${attributesStr}>
       ${elements}
     </${type}>`;
   }


### PR DESCRIPTION
Fixed Extra space in tags without attributes. 
e.g `<Activities >` --> `<Activities>`